### PR TITLE
タブ画面の原型と各画面への切り替えを実装する

### DIFF
--- a/ShoppingStar.xcodeproj/project.pbxproj
+++ b/ShoppingStar.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		781DD1C22B4ACE16000B501D /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1C12B4ACE16000B501D /* MainTabView.swift */; };
+		781DD1CA2B4AD45E000B501D /* ShoppingHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1C92B4AD45E000B501D /* ShoppingHomeView.swift */; };
+		781DD1CD2B4AD497000B501D /* EditingHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1CC2B4AD497000B501D /* EditingHomeView.swift */; };
+		781DD1CF2B4AD4B8000B501D /* CreateItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1CE2B4AD4B8000B501D /* CreateItemView.swift */; };
+		781DD1D22B4AD4E2000B501D /* SettingHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1D12B4AD4E2000B501D /* SettingHomeView.swift */; };
+		781DD1D52B4AD504000B501D /* AccountHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781DD1D42B4AD504000B501D /* AccountHomeView.swift */; };
 		78ACCAFA2B49AC34004639F2 /* ShoppingStarApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ACCAF92B49AC34004639F2 /* ShoppingStarApp.swift */; };
 		78ACCAFC2B49AC34004639F2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ACCAFB2B49AC34004639F2 /* ContentView.swift */; };
 		78ACCAFE2B49AC35004639F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 78ACCAFD2B49AC35004639F2 /* Assets.xcassets */; };
@@ -36,6 +41,11 @@
 
 /* Begin PBXFileReference section */
 		781DD1C12B4ACE16000B501D /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		781DD1C92B4AD45E000B501D /* ShoppingHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingHomeView.swift; sourceTree = "<group>"; };
+		781DD1CC2B4AD497000B501D /* EditingHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingHomeView.swift; sourceTree = "<group>"; };
+		781DD1CE2B4AD4B8000B501D /* CreateItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateItemView.swift; sourceTree = "<group>"; };
+		781DD1D12B4AD4E2000B501D /* SettingHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHomeView.swift; sourceTree = "<group>"; };
+		781DD1D42B4AD504000B501D /* AccountHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountHomeView.swift; sourceTree = "<group>"; };
 		78ACCAF62B49AC34004639F2 /* ShoppingStar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShoppingStar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78ACCAF92B49AC34004639F2 /* ShoppingStarApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoppingStarApp.swift; sourceTree = "<group>"; };
 		78ACCAFB2B49AC34004639F2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -85,6 +95,7 @@
 		781DD1C32B4ACE2B000B501D /* ShoppingTab */ = {
 			isa = PBXGroup;
 			children = (
+				781DD1C82B4AD43D000B501D /* ShoppingHomeView */,
 			);
 			path = ShoppingTab;
 			sourceTree = "<group>";
@@ -92,6 +103,7 @@
 		781DD1C42B4ACE40000B501D /* EditingTab */ = {
 			isa = PBXGroup;
 			children = (
+				781DD1CB2B4AD47B000B501D /* EditingHomeView */,
 			);
 			path = EditingTab;
 			sourceTree = "<group>";
@@ -99,6 +111,7 @@
 		781DD1C52B4ACE51000B501D /* CreateItemView */ = {
 			isa = PBXGroup;
 			children = (
+				781DD1CE2B4AD4B8000B501D /* CreateItemView.swift */,
 			);
 			path = CreateItemView;
 			sourceTree = "<group>";
@@ -106,6 +119,7 @@
 		781DD1C62B4ACEBB000B501D /* SettingTab */ = {
 			isa = PBXGroup;
 			children = (
+				781DD1D02B4AD4C9000B501D /* SettingHomeView */,
 			);
 			path = SettingTab;
 			sourceTree = "<group>";
@@ -113,8 +127,41 @@
 		781DD1C72B4ACF88000B501D /* AccountTab */ = {
 			isa = PBXGroup;
 			children = (
+				781DD1D32B4AD4ED000B501D /* AccountHomeView */,
 			);
 			path = AccountTab;
+			sourceTree = "<group>";
+		};
+		781DD1C82B4AD43D000B501D /* ShoppingHomeView */ = {
+			isa = PBXGroup;
+			children = (
+				781DD1C92B4AD45E000B501D /* ShoppingHomeView.swift */,
+			);
+			path = ShoppingHomeView;
+			sourceTree = "<group>";
+		};
+		781DD1CB2B4AD47B000B501D /* EditingHomeView */ = {
+			isa = PBXGroup;
+			children = (
+				781DD1CC2B4AD497000B501D /* EditingHomeView.swift */,
+			);
+			path = EditingHomeView;
+			sourceTree = "<group>";
+		};
+		781DD1D02B4AD4C9000B501D /* SettingHomeView */ = {
+			isa = PBXGroup;
+			children = (
+				781DD1D12B4AD4E2000B501D /* SettingHomeView.swift */,
+			);
+			path = SettingHomeView;
+			sourceTree = "<group>";
+		};
+		781DD1D32B4AD4ED000B501D /* AccountHomeView */ = {
+			isa = PBXGroup;
+			children = (
+				781DD1D42B4AD504000B501D /* AccountHomeView.swift */,
+			);
+			path = AccountHomeView;
 			sourceTree = "<group>";
 		};
 		78ACCAED2B49AC34004639F2 = {
@@ -311,8 +358,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				78ACCAFC2B49AC34004639F2 /* ContentView.swift in Sources */,
+				781DD1D52B4AD504000B501D /* AccountHomeView.swift in Sources */,
+				781DD1CA2B4AD45E000B501D /* ShoppingHomeView.swift in Sources */,
 				78ACCAFA2B49AC34004639F2 /* ShoppingStarApp.swift in Sources */,
 				781DD1C22B4ACE16000B501D /* MainTabView.swift in Sources */,
+				781DD1CD2B4AD497000B501D /* EditingHomeView.swift in Sources */,
+				781DD1CF2B4AD4B8000B501D /* CreateItemView.swift in Sources */,
+				781DD1D22B4AD4E2000B501D /* SettingHomeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ShoppingStar/AccountTab/AccountHomeView/AccountHomeView.swift
+++ b/ShoppingStar/AccountTab/AccountHomeView/AccountHomeView.swift
@@ -1,0 +1,18 @@
+//
+//  AccountHomeView.swift
+//  ShoppingStar
+//
+//  Created by 本川晴彦 on 2024/01/07.
+//
+
+import SwiftUI
+/// アカウントホーム画面
+struct AccountHomeView: View {
+    var body: some View {
+        Text("AccountHomeView")
+    }
+}
+
+#Preview {
+    AccountHomeView()
+}

--- a/ShoppingStar/CreateItemView/CreateItemView.swift
+++ b/ShoppingStar/CreateItemView/CreateItemView.swift
@@ -1,0 +1,18 @@
+//
+//  CreateItemView.swift
+//  ShoppingStar
+//
+//  Created by 本川晴彦 on 2024/01/07.
+//
+
+import SwiftUI
+/// 商品追加画面
+struct CreateItemView: View {
+    var body: some View {
+        Text("CreateItemView")
+    }
+}
+
+#Preview {
+    CreateItemView()
+}

--- a/ShoppingStar/EditingTab/EditingHomeView/EditingHomeView.swift
+++ b/ShoppingStar/EditingTab/EditingHomeView/EditingHomeView.swift
@@ -1,0 +1,18 @@
+//
+//  EditingHomeView.swift
+//  ShoppingStar
+//
+//  Created by 本川晴彦 on 2024/01/07.
+//
+
+import SwiftUI
+/// 編集ホーム画面
+struct EditingHomeView: View {
+    var body: some View {
+        Text("EditingHomeView")
+    }
+}
+
+#Preview {
+    EditingHomeView()
+}

--- a/ShoppingStar/MainTabView.swift
+++ b/ShoppingStar/MainTabView.swift
@@ -6,13 +6,122 @@
 //
 
 import SwiftUI
-
+/// 主要タブ画面
 struct MainTabView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  /// 選択したセレクションの種類
+  enum Selection {
+    case shopping
+    case editing
+    case create
+    case setting
+    case account
+    /// タブのラベルのテキスト
+    var label: String {
+      switch self {
+        case .shopping:
+          "買い物"
+        case .editing:
+          "買い物編集"
+        case .create:
+          "商品追加"
+        case .setting:
+          "設 定"
+        case .account:
+          "アカウント関連"
+      }
     }
+    /// タブアイコンのシンボル名
+    var systemImage: String {
+      switch self {
+        case .shopping:
+          "cart"
+        case .editing:
+          "square.and.pencil"
+        case .create:
+          "plus.circle"
+        case .setting:
+          "gear"
+        case .account:
+          "person"
+      }
+    }
+  }
+  /// 選択したタブのセレクション
+  @State private var selection: Selection = .shopping
+  /// 最後に選択したセレクションを保持
+  @State private var lastSelection: Selection = .shopping
+  /// 商品追加画面をモーダル遷移させるためのフラグ
+  @State private var isCreateItemViewIsPresented: Bool = false
+  // MARK: - body
+  var body: some View {
+    TabView(selection: $selection) {
+      // 買い物ホーム画面
+      ShoppingHomeView()
+        .tabItem {
+          Label(
+            Selection.shopping.label,
+            systemImage: "cart"
+          )
+        }
+        .tag(Selection.shopping)
+      // 編集ホーム画面
+      EditingHomeView()
+        .tabItem {
+          Label(
+            Selection.editing.label,
+            systemImage: "square.and.pencil"
+          )
+        }
+        .tag(Selection.editing)
+      // 商品追加
+      Text("CreateItemView")
+        .tabItem {
+          Label(
+            Selection.create.label,
+            systemImage: "plus.circle"
+          )
+        }
+        .tag(Selection.create)
+        .sheet(isPresented: $isCreateItemViewIsPresented)  {
+          CreateItemView()
+        }
+      // 設定ホーム画面
+      SettingHomeView()
+        .tabItem {
+          Label(
+            Selection.setting.label,
+            systemImage: "gear"
+          )
+        }
+        .tag(Selection.setting)
+      // アカウントホーム画面
+      AccountHomeView()
+        .tabItem {
+          Label(
+            Selection.account.label,
+            systemImage: "person"
+          )
+        }
+        .tag(Selection.account)
+    } // TabView
+    .onChange(of: selection) { _ in
+      switch selection {
+        case .shopping:
+          lastSelection = selection
+        case .editing:
+          lastSelection = selection
+        case .create:
+          selection = lastSelection
+          isCreateItemViewIsPresented = true
+        case .setting:
+          lastSelection = selection
+        case .account:
+          lastSelection = selection
+      } // switch
+    } // onChange
+  } // body
 }
 
 #Preview {
-    MainTabView()
+  MainTabView()
 }

--- a/ShoppingStar/SettingTab/SettingHomeView/SettingHomeView.swift
+++ b/ShoppingStar/SettingTab/SettingHomeView/SettingHomeView.swift
@@ -1,0 +1,18 @@
+//
+//  SettingHomeView.swift
+//  ShoppingStar
+//
+//  Created by 本川晴彦 on 2024/01/07.
+//
+
+import SwiftUI
+/// 設定ホーム画面
+struct SettingHomeView: View {
+    var body: some View {
+        Text("SettingHomeView")
+    }
+}
+
+#Preview {
+    SettingHomeView()
+}

--- a/ShoppingStar/ShoppingTab/ShoppingHomeView/ShoppingHomeView.swift
+++ b/ShoppingStar/ShoppingTab/ShoppingHomeView/ShoppingHomeView.swift
@@ -1,0 +1,18 @@
+//
+//  ShoppingHomeView.swift
+//  ShoppingStar
+//
+//  Created by 本川晴彦 on 2024/01/07.
+//
+
+import SwiftUI
+/// 買い物ホーム画面
+struct ShoppingHomeView: View {
+    var body: some View {
+        Text("ShoppingHomeView")
+    }
+}
+
+#Preview {
+    ShoppingHomeView()
+}


### PR DESCRIPTION
#1 

- 各画面を仮で実装
- タブ画面に各ビューを割り当て
- 商品追加画面だけはタブ遷移ではなく、モーダル遷移させるように実装