### PR TITLE
Feature/#5 viewer function of the photo view of the item cell

### DIFF
--- a/ShoppingStar.xcodeproj/project.pbxproj
+++ b/ShoppingStar.xcodeproj/project.pbxproj
@@ -598,7 +598,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "touch README.md";
@@ -636,7 +636,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "touch README.md";

--- a/ShoppingStar/ShoppingTab/ShoppingHomeView/ShoppingHomeView.swift
+++ b/ShoppingStar/ShoppingTab/ShoppingHomeView/ShoppingHomeView.swift
@@ -58,7 +58,10 @@ struct ShoppingHomeView: View {
         Divider()
         // 切り替える画面
         TabView(selection: $shoppingSelection) {
-          ShoppingListView(screenWidth: geometry.size.width)
+          ShoppingListView(
+            screenWidth: .constant(geometry.size.width),
+            screenHeight: .constant(geometry.size.height)
+          )
             .tag(Selection.list)
           ShoppingMapView()
             .tag(Selection.map)

--- a/ShoppingStar/ShoppingTab/ShoppingListView/ShoppingListView.swift
+++ b/ShoppingStar/ShoppingTab/ShoppingListView/ShoppingListView.swift
@@ -9,14 +9,17 @@ import SwiftUI
 
 struct ShoppingListView: View {
 
-  let screenWidth: CGFloat
+  @Binding var screenWidth: CGFloat
+
+  @Binding var screenHeight: CGFloat
   // MARK: - body
   var body: some View {
     ScrollView {
       LazyVStack(spacing: 15){
         ForEach(Item.dummy) { item in
           ItemCellView(
-            screenWidth: screenWidth,
+            screenWidth: $screenWidth,
+            screenHeight: $screenHeight,
             item: item,
             salesFloors: SalesFloor.default
           )
@@ -27,5 +30,8 @@ struct ShoppingListView: View {
 }
 
 #Preview {
-  ShoppingListView(screenWidth: 375)
+  ShoppingListView(
+    screenWidth: .constant(375),
+    screenHeight: .constant(670)
+  )
 }

--- a/ShoppingStar/Utility/Components/ItemCellView.swift
+++ b/ShoppingStar/Utility/Components/ItemCellView.swift
@@ -25,12 +25,14 @@ struct ItemCellView: View {
   var salesFloorColor: Color {
     SalesFloorColorType(rawValue: salesFloor.colorTypeRawValue)?.color ?? Color.white
   }
+  /// 写真のビューワーを表示させるフラグ
+  @State private var isImageViewerPresented: Bool = false
   // MARK: - body
   var body: some View {
     HStack(spacing: 20) {
       Image(systemName: "circle")
       cell()
-//              Image(systemName: "circle")
+      //              Image(systemName: "circle")
     } // HStack
     .padding(.horizontal, 10)
   } // body
@@ -76,15 +78,44 @@ private extension ItemCellView {
   }
   /// 画像のView
   @ViewBuilder func imageView() -> some View {
+    let screenWidthRatio = 0.9
+    let screenHeightRatio = 0.8
     if let url = item.dummyImageUrl {
-      Image(url)
-        .resizable()
-        .aspectRatio(contentMode: .fit)
-        .frame(width: screenWidth/5)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .background(RoundedRectangle(cornerRadius: 10)
-        .stroke(lineWidth: 2.0)
-        .foregroundStyle(.black))
+      Button {
+        isImageViewerPresented.toggle()
+      } label: {
+        Image(url)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: screenWidth/5)
+          .clipShape(RoundedRectangle(cornerRadius: 10))
+          .background(RoundedRectangle(cornerRadius: 10)
+            .stroke(lineWidth: 2.0)
+            .foregroundStyle(.black))
+      }
+      .sheet(isPresented: $isImageViewerPresented) {
+        VStack(spacing: 20) {
+          Image(url)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .background(RoundedRectangle(cornerRadius: 10)
+              .stroke(lineWidth: 2.0)
+              .foregroundStyle(.black))
+            .frame(
+              maxWidth: screenWidth * screenWidthRatio,
+              maxHeight: screenHeight * screenHeightRatio
+            )
+          Button {
+            isImageViewerPresented = false
+          } label: {
+            Text("閉じる")
+              .fontWeight(.semibold)
+              .tint(.white)
+          }
+        } // VStack
+        .presentationBackground(Color.black.opacity(0.8))
+      } // fullScreenCover
     } else {
       noImageView()
     }
@@ -111,7 +142,7 @@ private extension ItemCellView {
           .foregroundStyle(.white)
       } // VStack
     } // ZStack
-  } // VStack
+  }
   /// 備考を表示するViewで備考がなければ生成されない
   @ViewBuilder func remarksText() -> some View {
     if let remarksText = item.remarks {

--- a/ShoppingStar/Utility/Components/ItemCellView.swift
+++ b/ShoppingStar/Utility/Components/ItemCellView.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 /// 商品を表示するセル
 struct ItemCellView: View {
-  /// 画面サイズ
-  let screenWidth: CGFloat
+  /// 画面の横サイズ
+  @Binding var screenWidth: CGFloat
+  /// 画面の縦サイズ
+  @Binding var screenHeight: CGFloat
   /// 商品情報
   let item: Item
   /// 売り場の配列
@@ -124,7 +126,8 @@ private extension ItemCellView {
 
 #Preview {
   ItemCellView(
-    screenWidth: 375,
+    screenWidth: .constant(375),
+    screenHeight: .constant(680),
     item: .init(
       id: nil,
       name: "人参",


### PR DESCRIPTION

#5 

- ItemCellViewの写真をタップすると画像を拡大表示するシートを表示するように実装
- シートの背景は黒の半透明にするが、これをするとiOS16.4+にしないといけない
- シートに閉じるボタンを実装
- 画像をできるだけ大きくするように画面の横サイズだけでなく、縦サイズも首都くす用に変更
- 画面サイズをバインディングで取得するように変更